### PR TITLE
Revise Docker Strategy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,50 +1,11 @@
-FROM ubuntu:latest
+FROM benfalk/phoenix-elixir
 
-MAINTAINER Ben Falk <benjamin.falk@yahoo.com>
+ENV MIX_ENV prod
+ENV PORT 80
 
-# Elixir requires UTF-8
-RUN locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-
-# update and install some software requirements
-RUN apt-get update && apt-get upgrade -y && apt-get install -y curl wget git make
-
-# For some reason, installing Elixir tries to remove this file
-# and if it doesn't exist, Elixir won't install. So, we create it.
-# Thanks Daniel Berkompas for this tip.
-# http://blog.danielberkompas.com
-RUN touch /etc/init.d/couchdb
-
-# download and install Erlang package
-RUN wget http://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb \
-    && dpkg -i erlang-solutions_1.0_all.deb \
-    && apt-get update
-
-# install latest elixir and erlang package
-RUN apt-get install -y elixir erlang \
-    && rm erlang-solutions_1.0_all.deb
-
-ENV PHOENIX_VERSION 1.1.4
-
-# install the Phoenix Mix archive
-RUN mix archive.install --force https://github.com/phoenixframework/archives/raw/master/phoenix_new-$PHOENIX_VERSION.ez
-
-# install Node.js (>= 5.0.0) and NPM in order to satisfy brunch.io dependencies
-# See http://www.phoenixframework.org/docs/installation#section-node-js-5-0-0-
-RUN curl -sL https://deb.nodesource.com/setup_5.x | sudo -E bash - && apt-get install -y nodejs
-
-# Install hex and rebar, they are needed to compile a
-# phoenix application
-RUN mix local.hex --force
-RUN mix hex.info
-RUN mix local.rebar --force
-
-RUN apt-get install postgresql-client -y
-RUN apt-get install postgresql-9.3 -y \
-    && /etc/init.d/postgresql start \
-    && su postgres -c "echo alter user postgres with password \'postgres\' | psql" \
-    && /etc/init.d/postgresql stop
-
-WORKDIR /code
+ADD . /code
+RUN mix deps.get
+RUN npm install && /code/node_modules/brunch/bin/brunch build /code/
+RUN bash -c "mix compile.protocols 2>&1"
+RUN mix phoenix.digest
+CMD elixir -pa /code/_build/prod/consolidated -S mix phoenix.server

--- a/bin/test_suite
+++ b/bin/test_suite
@@ -1,0 +1,19 @@
+#!/bin/bash -l
+
+if ! command -v docker > /dev/null 2>&1; then
+  echo "Docker is required, Please consult https://docs.docker.com/"
+  exit 1
+fi
+
+if ! command -v docker-compose > /dev/null 2>&1; then
+  echo "Docker Compose is required, Please consult https://docs.docker.com/"
+  exit 1
+fi
+
+docker-compose stop
+docker-compose up -d database
+docker-compose run app bash -c "mix deps.get && npm set progress=false npm install --no-spin && MIX_ENV=test mix test 1>&1"
+result=$?
+docker-compose stop
+
+exit $result

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -36,8 +36,8 @@ config :phoenix, :stacktrace_depth, 20
 config :ganondorf, Ganondorf.Repo,
   adapter: Ecto.Adapters.Postgres,
   database: "ganondorf_dev",
-  hostname: "localhost",
-  username: "postgres",
-  password: "postgres",
+  hostname: System.get_env("DB_HOSTNAME") || "localhost",
+  username: System.get_env("DB_USERNAME") || "postgres",
+  password: System.get_env("DB_PASSWORD") || "postgres",
   template: "template0",
   pool_size: 10

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -19,6 +19,18 @@ config :ganondorf, Ganondorf.Endpoint,
 # Do not print debug messages in production
 config :logger, level: :info
 
+config :lodgings, OpenPlanet.Lodgings.Endpoint,
+  secret_key_base: System.get_env("SECRET_KEY_BASE")
+
+config :ganondorf, Ganondorf.Repo,
+  adapter: Ecto.Adapters.Postgres,
+  database: System.get_env("DB_NAME") || "ganondorf_prod",
+  hostname: System.get_env("DB_HOSTNAME") || "localhost",
+  username: System.get_env("DB_USERNAME") || "postgres",
+  password: System.get_env("DB_PASSWORD") || "postgres",
+  template: "template0",
+  pool_size: 20
+
 # ## SSL Support
 #
 # To get SSL working, you will need to add the `https` key
@@ -62,4 +74,4 @@ config :logger, level: :info
 
 # Finally import the config/prod.secret.exs
 # which should be versioned separately.
-import_config "prod.secret.exs"
+# import_config "prod.secret.exs"

--- a/config/test.exs
+++ b/config/test.exs
@@ -13,8 +13,8 @@ config :logger, level: :warn
 config :ganondorf, Ganondorf.Repo,
   adapter: Ecto.Adapters.Postgres,
   database: "ganondorf_test",
-  hostname: "localhost",
-  username: "postgres",
-  password: "postgres",
+  hostname: System.get_env("DB_HOSTNAME") || "localhost",
+  username: System.get_env("DB_USERNAME") || "postgres",
+  password: System.get_env("DB_PASSWORD") || "postgres",
   template: "template0",
   pool: Ecto.Adapters.SQL.Sandbox

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+database:
+  image: postgres
+  expose:
+    - "5432"
+app:
+  build: .
+  command: bash -c "mix deps.get && npm install && mix phoenix.server 2>&1"
+  volumes:
+    - .:/code
+  links:
+    - database:database.local
+  ports:
+    - "4000:4000"
+  environment:
+    DB_HOSTNAME: "database.local"
+    MIX_ENV: "dev"


### PR DESCRIPTION
Instead of having a large monolithic docker file I have elected to
use docker-compose to support the database.  I've also decided that
environment variables should drive the configuration over having
them defined in the files.  This allows you to set them with docker
later when running it in a production like environment.