### PR TITLE
Add Guardian to Session Stack

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -27,3 +27,12 @@ import_config "#{Mix.env}.exs"
 config :phoenix, :generators,
   migration: true,
   binary_id: false
+
+config :guardian, Guardian,
+  allowed_algos: ["HS512"], # optional
+  verify_module: Guardian.JWT,  # optional
+  issuer: "Ganondorf",
+  ttl: { 30, :days },
+  verify_issuer: true, # optional
+  secret_key: "PAr8fzW/MeBItVLEYQB5DF3/amRuXMzFlCcf9DTOrdUYiUZ3kX7NZ+ccDIU81Q2i",
+  serializer: Ganondorf.GuardianSerializer

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -22,6 +22,9 @@ config :logger, level: :info
 config :lodgings, OpenPlanet.Lodgings.Endpoint,
   secret_key_base: System.get_env("SECRET_KEY_BASE")
 
+config :guardian, Guardian,
+  secret_key: System.get_env("GUARDIAN_SECRET_KEY")
+
 config :ganondorf, Ganondorf.Repo,
   adapter: Ecto.Adapters.Postgres,
   database: System.get_env("DB_NAME") || "ganondorf_prod",

--- a/lib/ganondorf/guardian_serializer.ex
+++ b/lib/ganondorf/guardian_serializer.ex
@@ -1,0 +1,12 @@
+defmodule Ganondorf.GuardianSerializer do
+  @behaviour Guardian.Serializer
+
+  alias Ganondorf.Repo
+  alias Ganondorf.User
+
+  def for_token(user = %User{}), do: { :ok, "User:#{user.id}" }
+  def for_token(_), do: { :error, "Unknown resource type" }
+
+  def from_token("User:" <> id), do: { :ok, Repo.get(User, id) }
+  def from_token(_), do: { :error, "Unknown resource type" }
+end

--- a/mix.exs
+++ b/mix.exs
@@ -37,6 +37,7 @@ defmodule Ganondorf.Mixfile do
      {:phoenix_live_reload, "~> 1.0", only: :dev},
      {:gettext, "~> 0.9"},
      {:comeonin, "~> 2.4"},
+     {:guardian, "~> 0.10.0"},
      {:cowboy, "~> 1.0"}]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
-%{"comeonin": {:hex, :comeonin, "2.4.0"},
+%{"base64url": {:hex, :base64url, "0.0.1"},
+  "comeonin": {:hex, :comeonin, "2.4.0"},
   "connection": {:hex, :connection, "1.0.2"},
   "cowboy": {:hex, :cowboy, "1.0.4"},
   "cowlib": {:hex, :cowlib, "1.0.2"},
@@ -7,6 +8,8 @@
   "ecto": {:hex, :ecto, "1.1.5"},
   "fs": {:hex, :fs, "0.9.2"},
   "gettext": {:hex, :gettext, "0.10.0"},
+  "guardian": {:hex, :guardian, "0.10.1"},
+  "jose": {:hex, :jose, "1.7.3"},
   "phoenix": {:hex, :phoenix, "1.1.4"},
   "phoenix_ecto": {:hex, :phoenix_ecto, "2.0.1"},
   "phoenix_html": {:hex, :phoenix_html, "2.5.1"},
@@ -15,4 +18,5 @@
   "poison": {:hex, :poison, "1.5.2"},
   "poolboy": {:hex, :poolboy, "1.5.1"},
   "postgrex": {:hex, :postgrex, "0.11.1"},
-  "ranch": {:hex, :ranch, "1.2.1"}}
+  "ranch": {:hex, :ranch, "1.2.1"},
+  "uuid": {:hex, :uuid, "1.1.3"}}

--- a/web/controllers/registration_controller.ex
+++ b/web/controllers/registration_controller.ex
@@ -16,7 +16,7 @@ defmodule Ganondorf.RegistrationController do
       {:ok, new_user} ->
         conn
         |> put_flash(:info, "Successfully registered and logged in")
-        |> put_session(:current_user, new_user)
+        |> Guardian.Plug.sign_in(new_user)
         |> redirect(to: page_path(conn, :index))
     end
   end

--- a/web/controllers/session_controller.ex
+++ b/web/controllers/session_controller.ex
@@ -14,15 +14,15 @@ defmodule Ganondorf.SessionController do
       {:error, changeset} -> render conn, "new.html", changeset: changeset
       {:ok, user} ->
         conn
-        |> put_session(:current_user, user)
+        |> Guardian.Plug.sign_in(user)
         |> put_flash(:info, "Welcome back!")
         |> redirect(to: page_path(conn, :index))
     end
   end
 
   def delete(conn, _params) do
-    delete_session(conn, :current_user)
+    Guardian.Plug.sign_out(conn)
     |> put_flash(:info, 'You have been logged out')
-    |> redirect(to: session_path(conn, :new))
+    |> redirect(to: page_path(conn, :index))
   end
 end

--- a/web/router.ex
+++ b/web/router.ex
@@ -7,6 +7,8 @@ defmodule Ganondorf.Router do
     plug :fetch_flash
     plug :protect_from_forgery
     plug :put_secure_browser_headers
+    plug Guardian.Plug.VerifySession
+    plug Guardian.Plug.LoadResource
   end
 
   pipeline :api do

--- a/web/templates/layout/app.html.eex
+++ b/web/templates/layout/app.html.eex
@@ -16,7 +16,11 @@
       <header class="header">
         <nav role="navigation">
           <ul class="nav nav-pills pull-right">
-            <!-- <li><a href="http://www.phoenixframework.org/docs">Get Started</a></li> -->
+            <%= if signed_in?(@conn) do %>
+              <li><%= link("Sign Out", to: session_path(@conn, :delete), class: "btn pull-right") %></li>
+            <% else %>
+              <li><%= link("Sign In", to: session_path(@conn, :new), class: "btn pull-right") %></li>
+            <% end %>
           </ul>
         </nav>
         <span class="logo"></span>

--- a/web/views/layout_view.ex
+++ b/web/views/layout_view.ex
@@ -1,3 +1,17 @@
 defmodule Ganondorf.LayoutView do
   use Ganondorf.Web, :view
+
+  def signed_in?(conn) do
+    case Guardian.Plug.current_resource(conn) do
+      nil -> false
+      any -> true
+    end
+  end
+
+  def get_user(conn) do
+    case Guardian.Plug.current_resource(conn) do
+      nil -> ""
+      user -> "#{user.username}"
+    end
+  end
 end


### PR DESCRIPTION
This introduces Guardian as the authentication token.  It keeps a
JSON Web Token (JWT) browser side and stores the user details
encrypted in it.  The browser pipeline looks for this token, get's
the information from the token and pulls the user with it.

I've decided to use Guardian as it appears to be a good system
to store users auth token and is well documented.

I've also slipped in a `signed_in?` detection and have added a
"sign-in/sign-out" button that's based on your logged in status.